### PR TITLE
Responder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,4 +48,4 @@ pub use framed_write::{FramedWrite, FramedWriteParts};
 mod fuse;
 
 mod recvsend;
-pub use recvsend::{CloseStream, Event, RecvSend, ResponsePlaceholder, ReturnStream};
+pub use recvsend::{CloseStream, Event, RecvSend, Responder, ReturnStream};


### PR DESCRIPTION
I thought `Responder` (or `ResponseSender`) is a clearer name than `let slot: Sender`.

I also implemented support for dropping responder without sending any response (and added test case for it).

I also did some minor tweaks here and there, I find it much easier to read code when `_` is replaced with `_request`, especially when reviewing code on GitHub.

I was hesitant whether to call method `respond` or `send`.